### PR TITLE
FLPATH-677: Implement POST on FE

### DIFF
--- a/plugins/notifications-frontend/package.json
+++ b/plugins/notifications-frontend/package.json
@@ -35,7 +35,8 @@
     "react-use": "^17.2.4"
   },
   "peerDependencies": {
-    "react": "^16.13.1 || ^17.0.0"
+    "react": "^16.13.1 || ^17.0.0",
+    "react-router-dom": "^6.11.2"
   },
   "devDependencies": {
     "@backstage/cli": "0.22.9",

--- a/plugins/notifications-frontend/src/api/NotificationsApiImpl.ts
+++ b/plugins/notifications-frontend/src/api/NotificationsApiImpl.ts
@@ -1,6 +1,7 @@
 import { ConfigApi, IdentityApi } from '@backstage/core-plugin-api';
 
 import {
+  CreateNotificationRequest,
   Notification,
   NotificationsApi,
   NotificationsCountQuery,
@@ -38,10 +39,20 @@ export class NotificationsApiImpl implements NotificationsApi {
     }
   }
 
-  post(notification: Notification): Promise<string> {
-    // eslint-disable-next-line no-console
-    console.log('TODO: implement post notification: ', notification);
-    return Promise.resolve('id-todo');
+  async post(notification: CreateNotificationRequest): Promise<string> {
+    const url = new URL(`${this.backendUrl}/api/notifications/notifications`);
+
+    const response = await fetch(url.href, {
+      method: 'POST',
+      body: JSON.stringify(notification),
+      headers: { 'Content-Type': 'application/json' },
+    });
+    const data = await response.json();
+    if (response.status !== 200 && response.status !== 201) {
+      throw new Error(data.message);
+    }
+
+    return Promise.resolve(data.msgid);
   }
 
   async getNotifications(query: NotificationsQuery): Promise<Notification[]> {

--- a/plugins/notifications-frontend/src/api/notificationsApi.ts
+++ b/plugins/notifications-frontend/src/api/notificationsApi.ts
@@ -45,9 +45,20 @@ export type NotificationsCountQuery = NotificationsFilter & {
   unreadOnly?: boolean;
 };
 
+// Keep in sync with BE: plugins/notifications-backend/src/service/types.ts
+export type CreateNotificationRequest = {
+  origin: string;
+  title: string;
+  message?: string;
+  actions?: { title: string; url: string }[];
+  topic?: string;
+  targetUsers?: string[];
+  targetGroups?: string[];
+};
+
 export interface NotificationsApi {
   /** Create a notification. Returns its new ID. */
-  post(notification: Notification): Promise<string>;
+  post(notification: CreateNotificationRequest): Promise<string>;
 
   /** Read a list of notifications based on filter parameters. */
   getNotifications(query?: NotificationsQuery): Promise<Notification[]>;

--- a/plugins/notifications-frontend/src/components/NotificationsPage/NotificationsPage.tsx
+++ b/plugins/notifications-frontend/src/components/NotificationsPage/NotificationsPage.tsx
@@ -1,25 +1,43 @@
 import React from 'react';
+import { useParams } from 'react-router-dom';
 
 import { Page, RoutedTabs } from '@backstage/core-components';
 
 import { PersonalNotifications } from '../PersonalNotifications';
+import { SendNotification } from '../SendNotification';
 import { SystemNotifications } from '../SystemNotifications';
 
-export const NotificationsPage = () => (
-  <Page themeId="tool">
-    <RoutedTabs
-      routes={[
-        {
-          path: 'personal',
-          title: 'Personal',
-          children: <PersonalNotifications />,
-        },
-        {
-          path: 'updates',
-          title: 'Updates',
-          children: <SystemNotifications />,
-        },
-      ]}
-    />
-  </Page>
-);
+export const NotificationsPage = () => {
+  const params = useParams();
+  const isSend = params['*'] === 'send';
+
+  const routes = [
+    {
+      path: 'personal',
+      title: 'Personal',
+      children: <PersonalNotifications />,
+    },
+    {
+      path: 'updates',
+      title: 'Updates',
+      children: <SystemNotifications />,
+    },
+  ];
+
+  if (isSend) {
+    // This tab is not displayed by default, only when directly navigated by the URL.
+    // Meant for demonstration and debug purposes, since the notifications are
+    // expected to be send by 3rd party FE/BE plugins or external systems.
+    routes.push({
+      path: 'send',
+      title: 'Send',
+      children: <SendNotification />,
+    });
+  }
+
+  return (
+    <Page themeId="tool">
+      <RoutedTabs routes={routes} />
+    </Page>
+  );
+};

--- a/plugins/notifications-frontend/src/components/SendNotification/SendNotification.tsx
+++ b/plugins/notifications-frontend/src/components/SendNotification/SendNotification.tsx
@@ -1,0 +1,192 @@
+import React from 'react';
+
+import { configApiRef, useApi } from '@backstage/core-plugin-api';
+
+import { makeStyles } from '@material-ui/core';
+import Alert from '@mui/material/Alert';
+import Button from '@mui/material/Button';
+import Stack from '@mui/material/Stack';
+import TextField from '@mui/material/TextField';
+import Typography from '@mui/material/Typography';
+
+import { CreateNotificationRequest, notificationsApiRef } from '../../api';
+
+const useStyles = makeStyles({
+  container: {
+    width: '60%',
+    minWidth: '30rem',
+  },
+});
+
+export const SendNotification = () => {
+  const notificationsApi = useApi(notificationsApiRef);
+  const configApi = useApi(configApiRef);
+  const styles = useStyles();
+
+  const [notificationId, setNotificationId] = React.useState<string>();
+  const [error, setError] = React.useState<string>();
+
+  const [origin, setOrigin] = React.useState<string>('my-origin');
+  const [title, setTitle] = React.useState<string>('my-title');
+  const [message, setMessage] = React.useState<string>();
+  const [topic, setTopic] = React.useState<string>();
+  const [targetUsers, setTargetUsers] = React.useState<string[]>();
+  const [targetGroups, setTargetGroups] = React.useState<string[]>();
+  const [actions, setActions] = React.useState<string>();
+
+  const handleSubmit = async () => {
+    try {
+      const parsedActions = actions ? JSON.parse(actions) : undefined;
+
+      const notification: CreateNotificationRequest = {
+        origin,
+        title,
+        message,
+        actions: parsedActions,
+        topic,
+        targetUsers,
+        targetGroups,
+      };
+
+      const id = await notificationsApi.post(notification);
+      setNotificationId(id);
+    } catch (_e) {
+      const e = _e as Error;
+      setError(e.message);
+    }
+  };
+
+  const getCurl = () => {
+    const data: CreateNotificationRequest = {
+      title,
+      origin,
+    };
+
+    try {
+      if (message) {
+        data.message = message;
+      }
+      if (topic) {
+        data.topic = topic;
+      }
+      if (actions) {
+        data.actions = JSON.parse(actions);
+      }
+      if (targetUsers && targetUsers.length > 0) {
+        data.targetUsers = targetUsers;
+      }
+      if (targetGroups && targetGroups.length > 0) {
+        data.targetGroups = targetGroups;
+      }
+
+      return `curl -X POST ${configApi.getString(
+        'backend.baseUrl',
+      )}/api/notifications/notifications -H "Content-Type: application/json" -d '${JSON.stringify(
+        data,
+      )}'`;
+    } catch {
+      return 'Incorrect input';
+    }
+  };
+
+  return (
+    <>
+      <Stack className={styles.container} spacing={3}>
+        {error && <Alert severity="error">{error}</Alert>}
+
+        {notificationId && (
+          <Alert severity="info">
+            A notification has been created with id: ${notificationId}
+          </Alert>
+        )}
+
+        <form>
+          <Stack spacing={2}>
+            <TextField
+              required
+              id="title"
+              label="Title"
+              onChange={e => setTitle(e.target.value)}
+              value={title}
+            />
+
+            <TextField
+              id="message"
+              label="Message"
+              onChange={e => setMessage(e.target.value)}
+              value={message}
+            />
+
+            <TextField
+              required
+              id="origin"
+              label="Origin"
+              onChange={e => setOrigin(e.target.value)}
+              value={origin}
+            />
+
+            <TextField
+              id="topic"
+              label="Topic"
+              onChange={e => setTopic(e.target.value)}
+              value={topic}
+            />
+
+            <TextField
+              id="targetUsers"
+              label="Target users"
+              onChange={e =>
+                setTargetUsers(
+                  e.target.value
+                    ?.split(',')
+                    .map(v => v.trim())
+                    .filter(Boolean),
+                )
+              }
+              value={targetUsers?.join(',')}
+              helperText="Comma separated list. Example: jdoe,anotherUser"
+            />
+
+            <TextField
+              id="targetGroups"
+              label="Target user groups"
+              onChange={e =>
+                setTargetGroups(
+                  e.target.value
+                    ?.split(',')
+                    .map(v => v.trim())
+                    .filter(Boolean),
+                )
+              }
+              value={targetGroups?.join(',')}
+              helperText={
+                <>
+                  Comma separated list. Example: groupA,groupB
+                  <br />
+                  If both targetUsers and targetGroups are empty, the
+                  notification is system-wide (means: Updates)
+                </>
+              }
+            />
+
+            <TextField
+              id="actions"
+              label="Actions"
+              onChange={e => setActions(e.target.value)}
+              value={actions}
+              helperText='A JSON array of items with title and URL. Example: [ {"title": "My action", "url": "http://foo.bar"} ]'
+            />
+          </Stack>
+
+          <Button variant="outlined" onClick={handleSubmit}>
+            Create message
+          </Button>
+        </form>
+      </Stack>
+      <>
+        <Typography variant="h6">Example cURL</Typography>
+        <Typography paragraph>{getCurl()}</Typography>
+      </>
+    </>
+  );
+};

--- a/plugins/notifications-frontend/src/components/SendNotification/index.ts
+++ b/plugins/notifications-frontend/src/components/SendNotification/index.ts
@@ -1,0 +1,1 @@
+export * from './SendNotification';


### PR DESCRIPTION
Add a page to create notifications

Implemented as a tab on the NotificationsPage.

The new tab is not displayed by default, only when directly navigated by the URL ([BACKSTAGE]/notifications/send).

Meant for demonstration and debug purposes since the notifications are expected to be send by 3rd party FE/BE plugins or external systems.
