### PR TITLE
chore: use default/guest for external calls

### DIFF
--- a/plugins/notifications-backend/src/service/constants.ts
+++ b/plugins/notifications-backend/src/service/constants.ts
@@ -1,4 +1,4 @@
-export const DefaultServiceUser = 'default/externalServiceNotificationsUser';
+export const DefaultServiceUser = 'default/guest';
 export const DefaultMessageScope = 'user';
 export const DefaultPageNumber = 1;
 export const DefaultPageSize = 20;


### PR DESCRIPTION
Authentication of external systems is not stable anyway, so using the default/guest for them will simplify testing.